### PR TITLE
fix: increase maxWitnessItemSize to 4M, upgrade from ltcsuite

### DIFF
--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -96,17 +96,18 @@ const (
 
 	// maxWitnessItemsPerInput is the maximum number of witness items to
 	// be read for the witness data for a single TxIn. This number is
-	// derived using a possble lower bound for the encoding of a witness
+	// derived using a possible lower bound for the encoding of a witness
 	// item: 1 byte for length + 1 byte for the witness item itself, or two
 	// bytes. This value is then divided by the currently allowed maximum
-	// "cost" for a transaction.
-	maxWitnessItemsPerInput = 500000
+	// "cost" for a transaction. We use this for an upper bound for the
+	// buffer and consensus makes sure that the weight of a transaction
+	// cannot be more than 4000000.
+	maxWitnessItemsPerInput = 4_000_000
 
 	// maxWitnessItemSize is the maximum allowed size for an item within
-	// an input's witness data. This number is derived from the fact that
-	// for script validation, each pushed item onto the stack must be less
-	// than 10k bytes.
-	maxWitnessItemSize = 11000
+	// an input's witness data. This value is bounded by the largest
+	// possible block size, post segwit v1 (taproot).
+	maxWitnessItemSize = 4_000_000
 )
 
 // TxFlagMarker is the first byte of the FLAG field in a bitcoin tx
@@ -114,16 +115,18 @@ const (
 // transaction from one that would require a different parsing logic.
 //
 // Position of FLAG in a bitcoin tx message:
-//   ┌─────────┬────────────────────┬─────────────┬─────┐
-//   │ VERSION │ FLAG               │ TX-IN-COUNT │ ... │
-//   │ 4 bytes │ 2 bytes (optional) │ varint      │     │
-//   └─────────┴────────────────────┴─────────────┴─────┘
+//
+//	┌─────────┬────────────────────┬─────────────┬─────┐
+//	│ VERSION │ FLAG               │ TX-IN-COUNT │ ... │
+//	│ 4 bytes │ 2 bytes (optional) │ varint      │     │
+//	└─────────┴────────────────────┴─────────────┴─────┘
 //
 // Zooming into the FLAG field:
-//   ┌── FLAG ─────────────┬────────┐
-//   │ TxFlagMarker (0x00) │ TxFlag │
-//   │ 1 byte              │ 1 byte │
-//   └─────────────────────┴────────┘
+//
+//	┌── FLAG ─────────────┬────────┐
+//	│ TxFlagMarker (0x00) │ TxFlag │
+//	│ 1 byte              │ 1 byte │
+//	└─────────────────────┴────────┘
 const TxFlagMarker = 0x00
 
 // TxFlag is the second byte of the FLAG field in a bitcoin tx message.


### PR DESCRIPTION
replicate changes from https://github.com/ltcsuite/ltcd/pull/25 to fix the witness size